### PR TITLE
Add index to version field

### DIFF
--- a/diffHistoryModel.js
+++ b/diffHistoryModel.js
@@ -8,7 +8,7 @@ const historySchema = new Schema(
         diff: {},
         user: {},
         reason: String,
-        version: { type: Number, min: 0 }
+        version: { type: Number, min: 0, index: true }
     },
     {
         timestamps: true


### PR DESCRIPTION
Calls to `.sort(-version)` fail when running Mongo on Azure's CosmosDB.  See the Stack Overflow issue linked below.  This seemed like the easiest way to resolve the issue.

See: https://stackoverflow.com/questions/56988743/using-the-sort-cursor-method-without-the-default-indexing-policy-in-azure-cosm